### PR TITLE
added version lock for zapp

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,5 +16,6 @@ pylint==3.3.4
 pytest==8.3.4
 pytest-mock==3.14.0
 SQLAlchemy==2.0.38
+zipp==3.19.1
 tomlkit==0.13.2
 typing_extensions==4.12.2


### PR DESCRIPTION
Affected versions of zapp package are vulnerable to Infinite loop where an attacker can cause the application to stop responding by initiating a loop through functions affecting the Path module, such as joinpath, the overloaded division operator, and iterdir.  Pin zipp to version 3.19.1 
 